### PR TITLE
actually enable flip to shh

### DIFF
--- a/common/install.sh
+++ b/common/install.sh
@@ -21,6 +21,7 @@ WELLBEING_PREF_FILE=$INSTALLER/common/PhenotypePrefs.xml
 chmod 660 $WELLBEING_PREF_FILE
 WELLBEING_PREF_FOLDER=/data/data/com.google.android.apps.wellbeing/shared_prefs/
 if [ -f $WELLBEING_PREF_FOLDER ]; then
+  mkdir -p $WELLBEING_PREF_FOLDER
   cp -p $WELLBEING_PREF_FILE $WELLBEING_PREF_FOLDER
   am force-stop "com.google.android.apps.wellbeing"
 fi

--- a/common/install.sh
+++ b/common/install.sh
@@ -20,11 +20,9 @@ ui_print "   Enabling Google's Flip to Shhh..."
 WELLBEING_PREF_FILE=$INSTALLER/common/PhenotypePrefs.xml
 chmod 660 $WELLBEING_PREF_FILE
 WELLBEING_PREF_FOLDER=/data/data/com.google.android.apps.wellbeing/shared_prefs/
-if [ -f $WELLBEING_PREF_FOLDER ]; then
-  mkdir -p $WELLBEING_PREF_FOLDER
-  cp -p $WELLBEING_PREF_FILE $WELLBEING_PREF_FOLDER
-  am force-stop "com.google.android.apps.wellbeing"
-fi
+mkdir -p $WELLBEING_PREF_FOLDER
+cp -p $WELLBEING_PREF_FILE $WELLBEING_PREF_FOLDER
+am force-stop "com.google.android.apps.wellbeing"
 
 keytest() {
   ui_print " - Vol Key Test -"


### PR DESCRIPTION
As we install Wellbeing via the module, the data folder in question will not actually exist.